### PR TITLE
Initial implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Ansible-node-exporter
+=====================
+
+This role installs the Prometheus node exporter using the [role by Ernestas Poskus][1] to do the leg
+work.  It is split out into a separate role because we want to use it both on our infrastructure
+servers and our Open edX instances.
+
+[1]: https://github.com/ernestas-poskus/ansible-prometheus

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# The basic auth password to access the node exporter.
+NODE_EXPORTER_PASSWORD: set-me-please
+
+NODE_EXPORTER_NGINX_CONFIG_PATH: /etc/nginx/sites-available/node-exporter
+NODE_EXPORTER_HTPASSWD_PATH: /etc/nginx/htpasswd
+
+NODE_EXPORTER_USE_SSL: true
+NODE_EXPORTER_SSL_CERT: /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
+NODE_EXPORTER_SSL_KEY: /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem
+
+NODE_EXPLORER_CONSUL_SERVICE:
+  service:
+    name: node-exporter
+    tags:
+      - node-exporter
+      - "{{ 'montitor-https' if NODE_EXPORTER_USE_SSL else 'monitor' }}"
+    port: 19100
+    enable_tag_override: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ NODE_EXPORTER_USE_SSL: true
 NODE_EXPORTER_SSL_CERT: /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
 NODE_EXPORTER_SSL_KEY: /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem
 
-NODE_EXPLORER_CONSUL_SERVICE:
+NODE_EXPORTER_CONSUL_SERVICE:
   service:
     name: node-exporter
     tags:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: reload nginx
+  service:
+    name: nginx
+    state: reloaded
+
+- name: reload consul
+  shell: "command -v consul && consul reload"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - name: ernestas-poskus.prometheus
+    prometheus_node_exporter_install: true
+    prometheus_install: false
+    prometheus_alert_manager_install: false
+    prometheus_install_dir: /opt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: create Consul service definition file
   copy:
-    content: "{{ NODE_EXPLORER_CONSUL_SERVICE | to_nice_json(indent=4) }}"
+    content: "{{ NODE_EXPORTER_CONSUL_SERVICE | to_nice_json }}"
     dest: /etc/consul/node-exporter.json
   notify:
     - reload consul

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: install passlib for htpasswd generation
+  apt:
+    name: python-passlib
+
+- name: generate htpasswd file for the Prometheus node exporter
+  htpasswd:
+    path: "{{ NODE_EXPORTER_HTPASSWD_PATH }}"
+    username: node-exporter
+    password: "{{ NODE_EXPORTER_PASSWORD }}"
+
+- name: set up nginx to reverse-proxy the Prometheus node exporter
+  template:
+    src: nginx-node-exporter.j2
+    dest: "{{ NODE_EXPORTER_NGINX_CONFIG_PATH }}"
+  notify:
+    - reload nginx
+
+- name: enable nginx site configuration
+  file:
+    src: "{{ NODE_EXPORTER_NGINX_CONFIG_PATH }}"
+    dest: /etc/nginx/sites-enabled/node-exporter
+    state: link
+  notify:
+    - reload nginx
+
+- name: allow Prometheus metrics collections
+  ufw:
+    rule: allow
+    port: 19100
+    proto: tcp
+
+- name: create Consul config directory
+  file:
+    path: /etc/consul
+    state: directory
+
+- name: create Consul service definition file
+  copy:
+    content: "{{ NODE_EXPLORER_CONSUL_SERVICE | to_nice_json(indent=4) }}"
+    dest: /etc/consul/node-exporter.json
+  notify:
+    - reload consul

--- a/templates/nginx-node-exporter.j2
+++ b/templates/nginx-node-exporter.j2
@@ -1,0 +1,15 @@
+server {
+    listen 0.0.0.0:19100 {% if NODE_EXPORTER_USE_SSL %}ssl {% endif %}http2 default;
+    server_name _;
+
+    {% if NODE_EXPORTER_USE_SSL -%}
+    ssl_certificate {{ NODE_EXPORTER_SSL_CERT }};
+    ssl_certificate_key {{ NODE_EXPORTER_SSL_KEY }};
+    {%- endif %}
+
+    location / {
+        proxy_pass http://localhost:9100/;
+        auth_basic "Prometheus Node Exporter";
+        auth_basic_user_file {{ NODE_EXPORTER_HTPASSWD_PATH }};
+    }
+}


### PR DESCRIPTION
This new role will be used by both the common-server role as well as by Ocim instances, which is the only reason why I implemented it as a separate role.  It should be configurable enough to work in both contexts.

I had to add some handlers that are also defined in other roles, but these handlers won't be available on Ocim.  There is also some slight duplication with the Consul role.  The Consul role runs later on than common-server on our infrastructure servers, so I couldn't rely on {{/etc/consul}} already to already exist.