### PR TITLE
Fix Consul reload handler.

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,4 +5,4 @@
     state: reloaded
 
 - name: reload consul
-  shell: "command -v consul && consul reload"
+  shell: "if command -v consul; then consul reload; fi"


### PR DESCRIPTION
The command using the `&&` shortcut returns a non-zero exit code if `consul` is not present, so Ansible considers it as failed.  The fixed command returns zero if consul does not exist, and the return code of `consul reload` if it does exist, which is what we want.